### PR TITLE
Add one-line curl installer via GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,50 @@
+name: Deploy install script
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'bootstrap/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+# Allow the workflow to publish to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, without cancelling in-progress runs
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate install script
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          bash -n bootstrap/install.sh
+          shellcheck bootstrap/install.sh
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: bootstrap
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,35 @@
 
 This project contains setup files for macOS and Linux (including GitHub Codespaces). The configurations are designed to be portable across different platforms and Homebrew installations.
 
-To setup everything clone this repository into your home folder (`cd ~`), then run `./setup.sh` to [stow](https://www.gnu.org/software/stow/manual/stow.html) all folders.
+### Quick install (one-liner)
+
+On a fresh machine, bootstrap everything with a single command:
+
+```bash
+curl -fsSL https://doidor.github.io/.dotfiles/install.sh | bash
+```
+
+This clones the repo into `~/.dotfiles` (or updates it if it already exists) and runs `setup.sh`, which installs dependencies and [stows](https://www.gnu.org/software/stow/manual/stow.html) all folders. The script lives in [`bootstrap/install.sh`](bootstrap/install.sh) and is published to GitHub Pages automatically by [`.github/workflows/deploy-pages.yml`](.github/workflows/deploy-pages.yml).
+
+> The `doidor.github.io` URL redirects to the canonical `https://tudorpopa.com/.dotfiles/install.sh` — both work. Always review a script before piping it into a shell.
+
+You can override the defaults with environment variables:
+
+```bash
+# clone somewhere else, or track a different branch
+DOTFILES_DIR=~/dev/dotfiles DOTFILES_BRANCH=main \
+  bash -c "$(curl -fsSL https://doidor.github.io/.dotfiles/install.sh)"
+```
+
+### Manual install
+
+Prefer to do it yourself? Clone into `~/.dotfiles` and run the setup script:
+
+```bash
+git clone https://github.com/doidor/.dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+./setup.sh
+```
 
 ### Prerequisites
 

--- a/bootstrap/index.html
+++ b/bootstrap/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>dotfiles · one-line install</title>
+  <meta name="description" content="Bootstrap doidor/.dotfiles on any macOS or Linux machine with a single curl command." />
+  <style>
+    :root {
+      --bg: #0d1117;
+      --panel: #161b22;
+      --border: #30363d;
+      --fg: #e6edf3;
+      --muted: #8b949e;
+      --accent: #58a6ff;
+      --green: #3fb950;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1rem;
+      background: radial-gradient(1200px 600px at 50% -10%, #1b2330, var(--bg));
+      color: var(--fg);
+      font: 16px/1.6 ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    }
+    main { width: 100%; max-width: 720px; }
+    h1 { font-size: 1.9rem; margin: 0 0 .25rem; letter-spacing: -0.02em; }
+    .sub { color: var(--muted); margin: 0 0 1.75rem; }
+    .cmd {
+      display: flex;
+      align-items: center;
+      gap: .75rem;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1rem 1.1rem;
+      overflow-x: auto;
+    }
+    .cmd code { white-space: nowrap; color: var(--fg); }
+    .cmd .prompt { color: var(--green); user-select: none; }
+    button {
+      margin-left: auto;
+      flex: none;
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      border-radius: 7px;
+      padding: .35rem .6rem;
+      cursor: pointer;
+      font: inherit;
+      font-size: .8rem;
+    }
+    button:hover { color: var(--fg); border-color: var(--accent); }
+    ol { color: var(--muted); margin: 1.75rem 0 0; padding-left: 1.25rem; }
+    ol li { margin: .35rem 0; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    footer { margin-top: 2rem; color: var(--muted); font-size: .85rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>dotfiles</h1>
+    <p class="sub">One command to set up a fresh macOS or Linux machine.</p>
+
+    <div class="cmd">
+      <span class="prompt">$</span>
+      <code id="cmd">curl -fsSL https://doidor.github.io/.dotfiles/install.sh | bash</code>
+      <button id="copy" type="button" aria-label="Copy command">Copy</button>
+    </div>
+
+    <ol>
+      <li>Clones <a href="https://github.com/doidor/.dotfiles">doidor/.dotfiles</a> into <code>~/.dotfiles</code> (or updates it).</li>
+      <li>Runs <code>setup.sh</code> — installs Homebrew, zsh + oh-my-zsh, neovim, tmux, fzf, ripgrep and more.</li>
+      <li>Symlinks every config with GNU Stow.</li>
+    </ol>
+
+    <footer>
+      Source: <a href="https://github.com/doidor/.dotfiles/blob/main/bootstrap/install.sh">bootstrap/install.sh</a>.
+      Review before piping to a shell.
+    </footer>
+  </main>
+
+  <script>
+    const btn = document.getElementById('copy');
+    const cmd = document.getElementById('cmd');
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(cmd.textContent.trim());
+        btn.textContent = 'Copied';
+        setTimeout(() => (btn.textContent = 'Copy'), 1500);
+      } catch (e) {
+        btn.textContent = 'Press ⌘/Ctrl+C';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Dotfiles bootstrap installer
+# -----------------------------
+# One-line setup for a fresh machine:
+#
+#   curl -fsSL https://doidor.github.io/.dotfiles/install.sh | bash
+#
+# What it does:
+#   1. Clones (or updates) doidor/.dotfiles into ~/.dotfiles
+#      (uses git when available, otherwise falls back to a tarball download)
+#   2. Runs ./setup.sh, which installs dependencies and stows the configs
+#
+# Optional environment overrides:
+#   DOTFILES_REPO      git URL to clone     (default: https://github.com/doidor/.dotfiles.git)
+#   DOTFILES_DIR       target directory     (default: $HOME/.dotfiles)
+#   DOTFILES_BRANCH    branch to check out  (default: main)
+#   DOTFILES_NO_SETUP  if set, skip running setup.sh after fetching
+
+set -euo pipefail
+
+REPO="${DOTFILES_REPO:-https://github.com/doidor/.dotfiles.git}"
+DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+BRANCH="${DOTFILES_BRANCH:-main}"
+TARBALL_URL="${DOTFILES_TARBALL:-https://github.com/doidor/.dotfiles/archive/refs/heads/${BRANCH}.tar.gz}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header()  { echo -e "\n${BLUE}==>${NC} ${1}"; }
+print_success() { echo -e "${GREEN}✓${NC} ${1}"; }
+print_warning() { echo -e "${YELLOW}!${NC} ${1}"; }
+print_error()   { echo -e "${RED}✗${NC} ${1}"; }
+
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) OS="macOS" ;;
+        Linux)  OS="Linux" ;;
+        *)      OS="$(uname -s)" ;;
+    esac
+    print_success "Detected ${OS}"
+}
+
+dir_has_contents() {
+    [ -d "$1" ] && [ -n "$(ls -A "$1" 2>/dev/null)" ]
+}
+
+clone_with_git() {
+    print_header "Cloning ${REPO} into ${DIR}..."
+    git clone --branch "$BRANCH" "$REPO" "$DIR"
+    print_success "Repository cloned"
+}
+
+update_existing() {
+    print_header "Existing clone found at ${DIR} — updating..."
+    git -C "$DIR" remote set-url origin "$REPO" 2>/dev/null || true
+    git -C "$DIR" fetch --quiet origin "$BRANCH"
+    git -C "$DIR" checkout --quiet "$BRANCH"
+    git -C "$DIR" merge --ff-only --quiet "origin/${BRANCH}" \
+        || print_warning "Could not fast-forward; leaving local changes untouched"
+    print_success "Repository updated"
+}
+
+download_tarball() {
+    print_header "git not found — downloading tarball from ${TARBALL_URL}..."
+    local tmp
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    curl -fsSL "$TARBALL_URL" -o "${tmp}/dotfiles.tar.gz"
+    tar -xzf "${tmp}/dotfiles.tar.gz" -C "$tmp"
+    local extracted
+    extracted="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+    if [ -z "$extracted" ]; then
+        print_error "Failed to extract tarball"
+        exit 1
+    fi
+    mkdir -p "$DIR"
+    cp -R "${extracted}/." "${DIR}/"
+    print_success "Downloaded dotfiles (without git history)"
+    print_warning "No git metadata yet — will convert to a full clone once git is available"
+}
+
+fetch_repo() {
+    if [ -d "${DIR}/.git" ]; then
+        update_existing
+        return
+    fi
+    if dir_has_contents "$DIR"; then
+        print_error "${DIR} already exists and is not a git checkout."
+        print_error "Remove it or set DOTFILES_DIR to a different path, then retry."
+        exit 1
+    fi
+    if command_exists git; then
+        clone_with_git
+    else
+        download_tarball
+    fi
+}
+
+run_setup() {
+    if [ -n "${DOTFILES_NO_SETUP:-}" ]; then
+        print_warning "DOTFILES_NO_SETUP set — skipping setup.sh"
+        return
+    fi
+    if [ ! -f "${DIR}/setup.sh" ]; then
+        print_error "setup.sh not found in ${DIR}"
+        exit 1
+    fi
+    chmod +x "${DIR}/setup.sh" 2>/dev/null || true
+    print_header "Running setup.sh..."
+    ( cd "$DIR" && ./setup.sh )
+}
+
+# If we fetched via tarball, turn the directory into a real git clone now that
+# setup.sh has (most likely) installed git. Safe no-op when already a clone.
+ensure_git_clone() {
+    command_exists git || return 0
+    [ -d "${DIR}/.git" ] && return 0
+    print_header "Converting ${DIR} into a tracked git clone..."
+    git -C "$DIR" init -q
+    git -C "$DIR" remote add origin "$REPO" 2>/dev/null \
+        || git -C "$DIR" remote set-url origin "$REPO"
+    if git -C "$DIR" fetch -q --depth=1 origin "$BRANCH"; then
+        git -C "$DIR" reset -q --hard "origin/${BRANCH}"
+        git -C "$DIR" checkout -q -B "$BRANCH"
+        git -C "$DIR" branch -q --set-upstream-to="origin/${BRANCH}" "$BRANCH" 2>/dev/null || true
+        print_success "Git history restored"
+    else
+        print_warning "Could not fetch git history; dotfiles are in place but not tracked"
+    fi
+}
+
+main() {
+    echo -e "${BLUE}"
+    echo "╔════════════════════════════════════════╗"
+    echo "║        Dotfiles Bootstrap Setup        ║"
+    echo "╚════════════════════════════════════════╝"
+    echo -e "${NC}"
+
+    detect_os
+    fetch_repo
+    run_setup
+    ensure_git_clone
+
+    echo
+    print_success "All done! Restart your terminal or run: source ~/.zshrc"
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -362,6 +362,13 @@ stow_dotfiles() {
 
     for folder in */; do
         folder="${folder%/}"
+        # Skip directories that are not stow packages (deploy/build assets)
+        case "$folder" in
+            bootstrap)
+                echo "  Skipping $folder (not a stow package)"
+                continue
+                ;;
+        esac
         echo "  Stowing $folder..."
         stow -D -t ~ "$folder" 2>/dev/null || true
         stow -t ~ "$folder"

--- a/test.sh
+++ b/test.sh
@@ -25,10 +25,19 @@ command_exists() {
 # Test 1: Shell script syntax with shellcheck
 echo -e "${BLUE}→ Checking shell scripts...${NC}"
 if command_exists shellcheck; then
-    if shellcheck setup.sh; then
-        echo -e "${GREEN}✓ setup.sh passed shellcheck${NC}"
-    else
-        echo -e "${RED}✗ setup.sh has shellcheck issues${NC}"
+    SHELL_SCRIPTS=("setup.sh" "bootstrap/install.sh")
+    SHELL_OK=1
+    for script in "${SHELL_SCRIPTS[@]}"; do
+        if [ -f "$script" ]; then
+            if shellcheck "$script"; then
+                echo -e "${GREEN}✓ $script passed shellcheck${NC}"
+            else
+                echo -e "${RED}✗ $script has shellcheck issues${NC}"
+                SHELL_OK=0
+            fi
+        fi
+    done
+    if [ $SHELL_OK -eq 0 ]; then
         ERRORS=$((ERRORS + 1))
     fi
 else


### PR DESCRIPTION
## Summary

Adds a one-line installer so a fresh machine can be set up with:

```bash
curl -fsSL https://doidor.github.io/.dotfiles/install.sh | bash
```

The script is published to this repo's **GitHub Pages** site by a new workflow. Because the account has a custom domain, the page is served at `https://tudorpopa.com/.dotfiles/install.sh` and the `doidor.github.io` URL 301-redirects there (`curl -fsSL` follows redirects).

## What it does

`bootstrap/install.sh`:
1. Clones (or updates) `doidor/.dotfiles` into `~/.dotfiles` — uses `git` when available, otherwise downloads the branch tarball and converts it into a real clone once `setup.sh` has installed git.
2. Runs `setup.sh` (installs dependencies + stows configs).

Supports `DOTFILES_REPO` / `DOTFILES_DIR` / `DOTFILES_BRANCH` / `DOTFILES_NO_SETUP` overrides.

## Changes

- `bootstrap/install.sh` — the bootstrap installer
- `bootstrap/index.html` — minimal landing page with the one-liner
- `.github/workflows/deploy-pages.yml` — validate (`bash -n` + `shellcheck`) then deploy `bootstrap/` to Pages on push to `main` / manual dispatch
- `setup.sh` — skip the `bootstrap` dir in the stow loop (it is not a stow package)
- `test.sh` — also `shellcheck bootstrap/install.sh`
- `README.md` — document the one-liner and manual install

## Validation

- `./test.sh` passes (shellcheck clean for `setup.sh` and `bootstrap/install.sh`)
- Smoke-tested all fetch paths locally: fresh `git clone`, update of an existing clone, and the tarball fallback → conversion to a tracked clone (45 files, clean tree)

## After merge

Pages is configured to build from GitHub Actions. The first push to `main` runs the deploy workflow and the script goes live within ~1 minute.
