### PR TITLE
setup.sh: make Homebrew installs fully non-interactive

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Run Homebrew unattended. Modern Homebrew enables "ask mode" by default, which
+# prompts for confirmation before every `brew install`. HOMEBREW_NO_ASK disables
+# that prompt so all dependency installs run without manual confirmation.
+export HOMEBREW_NO_ASK=1
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/setup.sh
+++ b/setup.sh
@@ -54,7 +54,9 @@ install_homebrew() {
         print_success "Homebrew already installed"
     else
         print_header "Installing Homebrew..."
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        # NONINTERACTIVE=1 skips Homebrew's "Press RETURN to continue" confirmation
+        # prompt so the install runs unattended (e.g. when scripted on Linux).
+        NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
         # Add Homebrew to PATH for this session
         if [ "$OS" = "macos" ]; then


### PR DESCRIPTION
## Summary

Makes `setup.sh` run Homebrew fully unattended on macOS and Linux. There are two separate prompts:

1. **The Homebrew installer** prints `Press RETURN/ENTER to continue or any other key to abort:` and blocks. It's only shown when `NONINTERACTIVE` is unset (the installer's `wait_for_user` gate), so the install is invoked with `NONINTERACTIVE=1`.
2. **Every `brew install`** — modern Homebrew enables **"ask mode" by default**, prompting for confirmation before downloading/installing each dependency (`brew install` help: `-y, --no-ask … Ask mode is the default`). Exporting `HOMEBREW_NO_ASK=1` disables it for all installs in the script.

## Changes

- `setup.sh` — `export HOMEBREW_NO_ASK=1` near the top (covers every `brew install`).
- `setup.sh` — run the Homebrew installer with `NONINTERACTIVE=1`.

## Why two switches

`NONINTERACTIVE` is read by the install script; `HOMEBREW_NO_ASK` is read by the `brew` command itself. The installer switch alone does **not** stop the per-package "ask mode" prompts, which is the confirmation you hit on Linux.

## Validation

- Verified against the official installer source (`wait_for_user` gated on `NONINTERACTIVE`) and the Homebrew manpage / local `brew install --help` on Homebrew 6.0.4 (`HOMEBREW_NO_ASK` documented; ask mode is default).
- `./test.sh` passes; `shellcheck setup.sh` clean.
- Genuine `sudo` password prompts are unaffected — only Homebrew's own confirmations are skipped.
